### PR TITLE
Add throwing methods for serialization

### DIFF
--- a/include/message_serialization/binary_serialization.h
+++ b/include/message_serialization/binary_serialization.h
@@ -29,7 +29,7 @@ namespace message_serialization
  * @throws on failure to open or write to a file stream
  */
 template<typename T>
-inline void serializeToBinary(const std::string& file, const T& message)
+inline void serializeToBinary(const T& message, const std::string& file)
 {
   uint32_t serial_size = ros::serialization::serializationLength(message);
   boost::shared_array<uint8_t> buffer(new uint8_t[serial_size]);
@@ -60,7 +60,7 @@ inline bool serializeToBinary(const std::string& file, const T& message) noexcep
 {
   try
   {
-    serializeToBinary(file, message);
+    serializeToBinary<T>(message, file);
   }
   catch (const std::exception& ex)
   {

--- a/include/message_serialization/binary_serialization.h
+++ b/include/message_serialization/binary_serialization.h
@@ -22,16 +22,14 @@
 
 namespace message_serialization
 {
-
 /**
  * @brief Serializes a ROS message to a binary file
  * @param file
  * @param message ROS message to serialize
- * @return
+ * @throws on failure to open or write to a file stream
  */
 template<typename T>
-inline bool serializeToBinary(const std::string& file,
-                              const T& message)
+inline void serializeToBinary(const std::string& file, const T& message)
 {
   uint32_t serial_size = ros::serialization::serializationLength(message);
   boost::shared_array<uint8_t> buffer(new uint8_t[serial_size]);
@@ -41,11 +39,68 @@ inline bool serializeToBinary(const std::string& file,
   std::ofstream ofs(file, std::ios::out|std::ios::binary);
   if(ofs)
   {
-    ofs.write((char*) buffer.get(), serial_size);
-    return ofs.good();
+      ofs.write((char*) buffer.get(), serial_size);
+      if(!ofs.good())
+        throw std::runtime_error("Failed to write to binary file stream at '" + file + "'");
+  }
+  else
+  {
+    throw std::runtime_error("Failed to open binary file stream at '" + file + "'");
+  }
+}
+
+/**
+ * @brief Serializes a ROS message to a binary file
+ * @param file
+ * @param message ROS message to serialize
+ * @return
+ */
+template<typename T>
+inline bool serializeToBinary(const std::string& file, const T& message) noexcept
+{
+  try
+  {
+    serializeToBinary(file, message);
+  }
+  catch (const std::exception& ex)
+  {
+    ROS_ERROR_STREAM("Serialization error: " << ex.what());
+    return false;
   }
 
-  return false;
+  return true;
+}
+
+/**
+ * @brief De-serializes a binary file into a ROS message
+ * @param file
+ * @param message (output) ROS message
+ * @return
+ * @throws on failure to open or read a file stream
+ */
+template <typename T>
+inline T deserializeFromBinary(const std::string& file)
+{
+  std::ifstream ifs(file, std::ios::in | std::ios::binary);
+  if (!ifs)
+    throw std::runtime_error("Failed to open binary file stream at '" + file + "'");
+
+  ifs.seekg(0, std::ios::end);
+  std::streampos end = ifs.tellg();
+  ifs.seekg(0, std::ios::beg);
+  std::streampos begin = ifs.tellg();
+  uint32_t file_size = end - begin;
+
+  boost::shared_array<uint8_t> ibuffer(new uint8_t[file_size]);
+  ifs.read((char*)ibuffer.get(), file_size);
+
+  T message;
+  ros::serialization::IStream istream(ibuffer.get(), file_size);
+  ros::serialization::deserialize(istream, message);
+
+  ifs.close();
+
+  return message;
 }
 
 /**
@@ -55,38 +110,19 @@ inline bool serializeToBinary(const std::string& file,
  * @return
  */
 template<typename T>
-inline bool deserializeFromBinary(const std::string& file,
-                                  T& message)
+inline bool deserializeFromBinary(const std::string& file, T& message) noexcept
 {
-  std::ifstream ifs(file, std::ios::in|std::ios::binary);
-  if(!ifs)
-  {
-    return false;
-  }
-
-  ifs.seekg(0, std::ios::end);
-  std::streampos end = ifs.tellg();
-  ifs.seekg(0, std::ios::beg);
-  std::streampos begin = ifs.tellg();
-  uint32_t file_size = end - begin;
-
-  boost::shared_array<uint8_t> ibuffer(new uint8_t[file_size]);
-  ifs.read((char*) ibuffer.get(), file_size);
-
-  bool success = true;
   try
   {
-    ros::serialization::IStream istream(ibuffer.get(), file_size);
-    ros::serialization::deserialize(istream, message);
+    message = deserializeFromBinary<T>(file);
   }
   catch (const std::exception &ex)
   {
     ROS_ERROR_STREAM("Deserialization error: '" << ex.what() << "'");
-    success = false;
+    return false;
   }
 
-  ifs.close();
-  return success;
+  return true;
 }
 
 /**
@@ -111,22 +147,37 @@ inline uint32_t serializeToBuffer(boost::shared_array<uint8_t>& buffer, const T&
  * @param size Buffer size
  * @param message (output) ROS message
  * @return success
+ * @throws on failure to deserialize the buffer
  */
 template <typename T>
-inline bool deserializeFromBuffer(uint8_t* const buffer, const uint32_t size, T& message)
+inline T deserializeFromBuffer(uint8_t* const buffer, const uint32_t size)
 {
-  bool success = true;
+  T message;
+  ros::serialization::IStream istream(buffer, size);
+  ros::serialization::deserialize(istream, message);
+  return message;
+}
+
+/**
+ * @brief De-serializes an array of known length into a ROS message
+ * @param buffer Data array buffer
+ * @param size Buffer size
+ * @param message (output) ROS message
+ * @return success
+ */
+template <typename T>
+inline bool deserializeFromBuffer(uint8_t* const buffer, const uint32_t size, T& message) noexcept
+{
   try
   {
-    ros::serialization::IStream istream(buffer, size);
-    ros::serialization::deserialize(istream, message);
+    message = deserializeFromBinary<T>(buffer, size);
   }
   catch (const std::exception& ex)
   {
     ROS_ERROR_STREAM("Deserialization error: '" << ex.what() << "'");
-    success = false;
+    return false;
   }
-  return success;
+  return true;
 }
 }  // namespace message_serialization
 

--- a/include/message_serialization/serialize.h
+++ b/include/message_serialization/serialize.h
@@ -29,7 +29,7 @@ namespace message_serialization
  * @throws exception on failure to open or write to a file stream
  */
 template <class T>
-void serialize(const std::string& file, const T& val)
+inline void serialize(const std::string& file, const T& val)
 {
   std::ofstream ofh(file);
   if (!ofh)
@@ -46,7 +46,7 @@ void serialize(const std::string& file, const T& val)
  * @return true on success, false otherwise
  */
 template <class T>
-bool serialize(const std::string& file, const T& val) noexcept
+inline bool serialize(const std::string& file, const T& val) noexcept
 {
   try
   {
@@ -67,7 +67,7 @@ bool serialize(const std::string& file, const T& val) noexcept
  * @throws exception when unable to load the file or convert it to the specified type
  */
 template <class T>
-T deserialize(const std::string &file)
+inline T deserialize(const std::string &file)
 {
   YAML::Node node;
   node = YAML::LoadFile(file);
@@ -81,7 +81,7 @@ T deserialize(const std::string &file)
  * @return true on success, false otherwise
  */
 template <class T>
-bool deserialize(const std::string &file, T& val) noexcept
+inline bool deserialize(const std::string &file, T& val) noexcept
 {
   try
   {

--- a/include/message_serialization/serialize.h
+++ b/include/message_serialization/serialize.h
@@ -24,12 +24,12 @@ namespace message_serialization
 {
 /**
  * @brief Serializes an input object to a YAML-formatted file
- * @param file
  * @param val
+ * @param file
  * @throws exception on failure to open or write to a file stream
  */
 template <class T>
-inline void serialize(const std::string& file, const T& val)
+inline void serialize(const T& val, const std::string& file)
 {
   std::ofstream ofh(file);
   if (!ofh)
@@ -50,7 +50,7 @@ inline bool serialize(const std::string& file, const T& val) noexcept
 {
   try
   {
-    serialize(file, val);
+    serialize<T>(val, file);
   }
   catch (const std::exception& ex)
   {

--- a/include/message_serialization/serialize.h
+++ b/include/message_serialization/serialize.h
@@ -22,37 +22,77 @@
 
 namespace message_serialization
 {
-
+/**
+ * @brief Serializes an input object to a YAML-formatted file
+ * @param file
+ * @param val
+ * @throws exception on failure to open or write to a file stream
+ */
 template <class T>
-bool serialize(const std::string &file, const T& val)
+void serialize(const std::string& file, const T& val)
 {
-  std::ofstream ofh (file);
+  std::ofstream ofh(file);
   if (!ofh)
-  {
-    return false;
-  }
+    throw std::runtime_error("Failed to open output file stream at '" + file + "'");
 
   YAML::Node n = YAML::Node(val);
   ofh << n;
-  return true;
 }
 
+/**
+ * @brief Serializes an input object to a YAML-formatted file
+ * @param file
+ * @param val
+ * @return true on success, false otherwise
+ */
 template <class T>
-bool deserialize(const std::string &file, T& val)
+bool serialize(const std::string& file, const T& val) noexcept
 {
   try
   {
-    YAML::Node node;
-    node = YAML::LoadFile(file);
-    val = node.as<T>();
-    return true;
+    serialize(file, val);
   }
-  catch (const YAML::Exception& ex)
+  catch (const std::exception& ex)
   {
-    ROS_ERROR_STREAM("An exception was thrown while processing file: " << file);
     ROS_ERROR_STREAM(ex.what());
     return false;
   }
+  return true;
+}
+
+/**
+ * @brief Deserializes a YAML-formatted file into a specific object type
+ * @param file
+ * @return
+ * @throws exception when unable to load the file or convert it to the specified type
+ */
+template <class T>
+T deserialize(const std::string &file)
+{
+  YAML::Node node;
+  node = YAML::LoadFile(file);
+  return node.as<T>();
+}
+
+/**
+ * @brief Deserializes a YAML-formatted file into a specific object type
+ * @param file
+ * @param val
+ * @return true on success, false otherwise
+ */
+template <class T>
+bool deserialize(const std::string &file, T& val) noexcept
+{
+  try
+  {
+    val = deserialize<T>(file);
+  }
+  catch (const std::exception& ex)
+  {
+    ROS_ERROR_STREAM("Deserialization error: " << ex.what());
+    return false;
+  }
+  return true;
 }
 
 } // namespace message_serialization


### PR DESCRIPTION
Per the title, this PR adds methods for serialization that throw exceptions rather than returning a success variable